### PR TITLE
Bugfix: Minibar switch-off not working after app restart

### DIFF
--- a/src/com/android/launcher3/Launcher.java
+++ b/src/com/android/launcher3/Launcher.java
@@ -396,6 +396,9 @@ public class Launcher extends BaseDraggingActivity implements LauncherExterns,
         }
         mRotationHelper.initialize();
         //initMinibar();
+        DrawerLayout dl = findViewById(R.id.drawer_layout);
+        dl.setDrawerLockMode(prefs.getMinibarEnable() ? DrawerLayout.LOCK_MODE_UNLOCKED : DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
+
         TraceHelper.endSection("Launcher-onCreate");
         Utilities.checkRestoreSuccess(this);
 


### PR DESCRIPTION
Currently, the setting `ZimFlags.MINIBAR_ENABLE` is not read at app startup, so if the Minibar is disabled it is still available after app restart.

Steps to reproduce:

1. Go to settings &rarr; Desktop &rarr; Minibar
2. Switch off the minibar
3. Restart the app (or the phone)
4. The Minibar can still be opened by swipe (bug),<br>after the bugfix the Minibar cannot be opened any more

To fix the bug I added two lines in `Launcher.onCreate()` to set the lock mode of the drawer.